### PR TITLE
refactor: code organization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,7 +238,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "flexispot_e7_controller_cli"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "clap",
  "flexispot_e7_controller_lib",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "flexispot_e7_controller_lib"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "rppal",
  "serde",
@@ -258,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "flexispot_e7_controller_web"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "axum",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,7 @@ dependencies = [
  "flexispot_e7_controller_lib",
  "flexispot_e7_controller_web",
  "ureq",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 authors = ["kaoru <k@warpnine.io>"]
 edition = "2021"
 repository = "https://github.com/0x6b/flexispot-e7-controller"
-version = "0.5.3"
+version = "0.5.4"
 
 [workspace.dependencies]
 clap = { version = "4.4.12", features = ["derive"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,3 +15,4 @@ clap.workspace = true
 flexispot_e7_controller_lib.workspace = true
 flexispot_e7_controller_web.workspace = true
 ureq = { version = "2.9.1", default-features = false, features = ["json"] }
+url = "2.5.0"

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -1,6 +1,4 @@
 use std::net::IpAddr;
-#[cfg(all(target_os = "linux", target_arch = "arm"))]
-use std::path::PathBuf;
 
 use clap::Subcommand;
 use flexispot_e7_controller_lib::Preset;
@@ -15,7 +13,7 @@ pub enum Mode {
 
         /// Path to serial device
         #[clap(long, default_value = "/dev/ttyS0")]
-        device: PathBuf,
+        device: std::path::PathBuf,
 
         /// GPIO (BCM) number of PIN 20
         #[clap(long, default_value = "12")]

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -6,9 +6,6 @@ use {
 };
 
 #[cfg(all(target_os = "linux", target_arch = "arm"))]
-use crate::command::Command;
-
-#[cfg(all(target_os = "linux", target_arch = "arm"))]
 pub fn execute(command: Command, device: PathBuf, pin20: u8) -> Result<(), Box<dyn Error>> {
     let mut controller = Controller::try_new_with(device, pin20)?;
     match command {

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -1,0 +1,21 @@
+#[cfg(all(target_os = "linux", target_arch = "arm"))]
+use {
+    crate::command::Command,
+    flexispot_e7_controller_lib::Controller,
+    std::{error::Error, path::PathBuf},
+};
+
+#[cfg(all(target_os = "linux", target_arch = "arm"))]
+use crate::command::Command;
+
+#[cfg(all(target_os = "linux", target_arch = "arm"))]
+pub fn execute(command: Command, device: PathBuf, pin20: u8) -> Result<(), Box<dyn Error>> {
+    let mut controller = Controller::try_new_with(device, pin20)?;
+    match command {
+        Command::Query => {
+            let height = controller.query()?;
+            println!("Current height: {height} cm");
+        }
+        _ => controller.execute(&command.into())?,
+    };
+}

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -15,4 +15,5 @@ pub fn execute(command: Command, device: PathBuf, pin20: u8) -> Result<(), Box<d
         }
         _ => controller.execute(&command.into())?,
     };
+    Ok(())
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,12 +1,9 @@
-use std::{env::var, error::Error, time::Duration};
-
 use clap::Parser;
-use command::{Command, Mode};
-#[cfg(all(target_os = "linux", target_arch = "arm"))]
-use flexispot_e7_controller_lib::Controller;
-use flexispot_e7_controller_web::{RequestPayload, ResponsePayload};
+use command::Mode;
 
 mod command;
+mod local;
+mod remote;
 
 #[derive(Parser, Debug)]
 #[clap(about, version)]
@@ -15,48 +12,13 @@ pub struct Args {
     pub mode: Mode,
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let Args { mode } = Args::parse();
 
     match mode {
         #[cfg(all(target_os = "linux", target_arch = "arm"))]
-        Mode::Local { command, device, pin20 } => {
-            let mut controller = Controller::try_new_with(device, pin20)?;
-            match command {
-                Command::Query => {
-                    let height = controller.query()?;
-                    println!("Current height: {height} cm");
-                }
-                _ => controller.execute(&command.into())?,
-            };
-        }
-        Mode::Remote { command, address, port } => {
-            let secret =
-                var("E7_SECRET").expect("Specify secret with E7_SECRET environment variable");
-            let client = ureq::AgentBuilder::new()
-                .timeout_connect(Duration::from_secs(1))
-                .timeout_read(Duration::from_secs(1))
-                .timeout_write(Duration::from_secs(1))
-                .build();
-
-            match command {
-                Command::Query => {
-                    let height = client
-                        .get(&format!("http://{address}:{port}/query"))
-                        .set("Authorization", &secret)
-                        .call()?
-                        .into_json::<ResponsePayload>()?;
-                    println!("Current height: {height} cm");
-                }
-                _ => {
-                    client
-                        .post(&format!("http://{address}:{port}/"))
-                        .set("Authorization", &secret)
-                        .send_json(RequestPayload { command: command.into() })?;
-                }
-            }
-        }
+        Mode::Local { command, device, pin20 } => local::execute(command, device, pin20)?,
+        Mode::Remote { command, address, port } => remote::execute(command, address, port)?,
     }
-
     Ok(())
 }

--- a/cli/src/remote.rs
+++ b/cli/src/remote.rs
@@ -1,0 +1,35 @@
+use std::{env::var, error::Error, net::IpAddr, time::Duration};
+
+use flexispot_e7_controller_web::{RequestPayload, ResponsePayload};
+use ureq::{MiddlewareNext, Request};
+use url::Url;
+
+use crate::command::Command;
+
+pub fn execute(command: Command, address: IpAddr, port: u16) -> Result<(), Box<dyn Error>> {
+    let secret = var("E7_SECRET").expect("Specify secret with E7_SECRET environment variable");
+
+    let client = ureq::AgentBuilder::new()
+        .timeout_connect(Duration::from_secs(1))
+        .timeout_read(Duration::from_secs(1))
+        .timeout_write(Duration::from_secs(1))
+        .middleware(move |req: Request, next: MiddlewareNext| {
+            next.handle(req.set("Authorization", &secret))
+        })
+        .build();
+    let mut url = Url::parse(&format!("http://{address}:{port}/"))?;
+
+    match command {
+        Command::Query => {
+            url.set_path("/query");
+            let height = client.get(url.as_str()).call()?.into_json::<ResponsePayload>()?;
+            println!("Current height: {height} cm");
+        }
+        _ => {
+            client
+                .post(url.as_str())
+                .send_json(RequestPayload { command: command.into() })?;
+        }
+    }
+    Ok(())
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,16 +1,15 @@
-#[cfg(all(target_os = "linux", target_arch = "arm"))]
-use std::{error::Error, path::PathBuf, thread::sleep, time::Duration};
-
 pub use command::{Command, Preset};
 #[cfg(all(target_os = "linux", target_arch = "arm"))]
-use command::{
-    Command::{Down, Go, Memory, Query, Set, Up, WakeUp},
-    CommandSequence,
-};
-#[cfg(all(target_os = "linux", target_arch = "arm"))]
-use rppal::{
-    gpio::{Gpio, OutputPin},
-    uart::{Parity, Uart},
+use {
+    command::{
+        Command::{Down, Go, Memory, Query, Set, Up, WakeUp},
+        CommandSequence,
+    },
+    rppal::{
+        gpio::{Gpio, OutputPin},
+        uart::{Parity, Uart},
+    },
+    std::{error::Error, path::PathBuf, thread::sleep, time::Duration},
 };
 
 mod command;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+# https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
+[toolchain]
+channel = "1.75.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
- refactor: qualify one-time import to reduce #[cfg] directive
- refactor: split commands into multiple modules to reduce #cfg directives
- refactor: merge imports to reduce #cfg directives
- build: specify rust toolchain explicitly
